### PR TITLE
Add defaultvalue for hour and minute for z3cform Datetime widget.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add defaultvalue for hour and minute for z3cform Datetime widget.
+  Fixes: https://github.com/plone/plone.formwidget.datetime/issues/14
+  [elioschmutz]
 
 
 1.1 (2014-11-06)

--- a/plone/formwidget/datetime/tests/test_DatetimeWidget.py
+++ b/plone/formwidget/datetime/tests/test_DatetimeWidget.py
@@ -128,3 +128,18 @@ class TestDatetimeWidget(unittest.TestCase):
             len(instance.extract()),
             5
         )
+
+    def test_extract__no_time(self):
+        instance = self.createInstance()
+        instance.request = {
+            'field-day': '21',
+            'field-month': '11',
+            'field-year': '2011',
+            'field-hour': '',
+            'field-minute': '',
+        }
+        default = mock.Mock()
+        self.assertEqual(
+            instance.extract(default),
+            ('2011', '11', '21', '00', '00')
+        )

--- a/plone/formwidget/datetime/z3cform/widget.py
+++ b/plone/formwidget/datetime/z3cform/widget.py
@@ -76,8 +76,8 @@ class DatetimeWidget(base.AbstractDatetimeWidget, AbstractDXDateWidget):
         day = self.request.get(self.name + '-day', default)
         month = self.request.get(self.name + '-month', default)
         year = self.request.get(self.name + '-year', default)
-        hour = self.request.get(self.name + '-hour', default)
-        minute = self.request.get(self.name + '-minute', default)
+        hour = self.request.get(self.name + '-hour', default) or '00'
+        minute = self.request.get(self.name + '-minute', default) or '00'
         timezone = self.request.get(self.name + '-timezone', default)
 
         if (self.ampm is True


### PR DESCRIPTION
Add defaultvalue for hour and minute for z3cform Datetime widget.

With this modification it's possible to add a date without a time for dexteritytypes. For more information please take a look at the issue.

Fixes https://github.com/plone/plone.formwidget.datetime/issues/14