### PR TITLE
Tuple ('', '', '', '00', '00') is also an empty value. Fix #22

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Tuple ('', '', '', '00', '00') is also an empty value. Fix #22
+  [batlock666]
 
 
 1.3.4 (2018-04-08)

--- a/plone/formwidget/datetime/base.py
+++ b/plone/formwidget/datetime/base.py
@@ -435,6 +435,13 @@ class AbstractDatetimeWidget(AbstractDateWidget):
         return self._base_dtvalue(datetime, value)
 
     @property
+    def formatted_value(self):
+        if self.value in (self.empty_value, self.empty_value[:-1], None):
+            return ''
+        dt_value = self._dtvalue(self.value)
+        return self.get_formatted_value(dt_value)
+
+    @property
     def hours(self):
         try:
             current = int(self.hour)

--- a/plone/formwidget/datetime/tests/test_AbstractDatetimeWidget.py
+++ b/plone/formwidget/datetime/tests/test_AbstractDatetimeWidget.py
@@ -280,3 +280,13 @@ class TestAbstractDatetimeWidget(unittest.TestCase):
         value = (1,2,3)
         instance._dtvalue(value)
         datetime.assert_called_with(1, 2, 3)
+
+    def test_formatted_value_value_is_empty_value(self):
+        instance = self.createInstance()
+
+        self.assertEqual(instance.value, ('', '', '', '00', '00', ''))
+        self.assertEqual(instance.formatted_value, '')
+
+        instance.value = instance.value[:-1]
+        self.assertEqual(instance.value, ('', '', '', '00', '00'))
+        self.assertEqual(instance.formatted_value, '')


### PR DESCRIPTION
This fixes issue #22.